### PR TITLE
Fix CNAME resolution

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
@@ -82,7 +81,7 @@ func createPlugin(c *caddy.Controller) (*Traefik, error) {
 				if !c.NextArg() {
 					return traefik, c.ArgErr()
 				}
-				val, _ := strings.CutSuffix(c.Val(), ".")
+				val := c.Val()
 				cfg.cname = &val
 				if mode == 1 {
 					return traefik, c.Err("traefik cname and a are mutually exclusive")

--- a/traefik.go
+++ b/traefik.go
@@ -242,7 +242,7 @@ func a(zone string, ttl uint32, ips []net.IP) []dns.RR {
 func cname(zone string, ttl uint32, target *string) []dns.RR {
 	answers := make([]dns.RR, 1)
 	r := new(dns.CNAME)
-	r.Hdr = dns.RR_Header{Name: zone, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: ttl}
+	r.Hdr = dns.RR_Header{Name: zone, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: ttl}
 	r.Target = *target
 	answers[0] = r
 	return answers


### PR DESCRIPTION
**The problem**
I was experiencing a weird issue when using a CNAME instead of a A record. The DNS would resolve correctly and return on my coredns server, but the clients would just time without returning any results. I believe that this user was experiencing something related: https://github.com/scottt732/coredns-traefik/issues/1#issue-2422595818

**The core issue and fix**
Stripping the trailing . causes DNS to interpret the CNAME record as a relative domain name. In such cases, the resolver attempts to append a locally configured search domain to the target. While this works in networks (or local resolvers) properly configured to handle search domains, it introduces unpredictability and cannot be consistently relied upon.

This fix ensures that DNS interprets the CNAME as a FQDN by preserving the trailing ".".

**Note on breaking changes**:
This change may impact users who previously configured their CNAME records with a trailing . (e.g., cname a.b.c.) but expected the domain to resolve as a relative name. To maintain the previous behaviour, those users must update their configuration by removing the trailing . (e.g., cname a.b.c).


