### PR TITLE
Fix server returning NOERROR when it should have been returning NXDOMAIN

### DIFF
--- a/traefik.go
+++ b/traefik.go
@@ -99,7 +99,7 @@ func (t *Traefik) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 
 	//goland:noinspection ALL
 	w.WriteMsg(m)
-	return dns.RcodeSuccess, nil
+	return r.Rcode, nil
 }
 
 func (t *Traefik) start() error {

--- a/traefik.go
+++ b/traefik.go
@@ -98,7 +98,7 @@ func (t *Traefik) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 	}
 
 	w.WriteMsg(m)
-	return m.Rcode, nil
+	return 0, nil
 }
 
 func (t *Traefik) start() error {


### PR DESCRIPTION
I found a bug in the error handling logic where calling `m.SetReply` after setting `m.Rcode`appears to overwrite the rcode to a success value.

This PR fixes the order-of-operations there.